### PR TITLE
Make cross-platform (incl. Windows), example of proper intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 HASHpy
 ------
 
-[![DOI](https://zenodo.org/badge/3723/markcwill/hashpy.png)](http://dx.doi.org/10.5281/zenodo.9808)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.9808.svg)](https://doi.org/10.5281/zenodo.9808)
 
-This is a fork of HASH v1.2, the first motion focal mechanism program by Hardebeck and Shearer. The subroutines (in Fortran 77, which I did not write) are compiled into a python module, 'libhashpy.so', which will import all the subs and common blocks into the python namespace. There is a base class, HashPype, that contains attributes which hold data for a HASH calculation, and methods which can be called to do the HASH calculation. This class facilitates easily writing a 'hash driver' script in python. See below for details.
+
+This is a fork of HASH v1.2, the first motion focal mechanism program by Hardebeck and Shearer. 
+The subroutines (in Fortran 77, which I did not write) are compiled into a python module, `libhashpy.so`, which will import all the subs and common blocks into the python namespace. 
+There is a base class, HashPype, that contains attributes which hold data for a HASH calculation, and methods which can be called to do the HASH calculation. 
+This class facilitates easily writing a 'hash driver' script in python. 
+See below for details.
 
 Note: As stated in the in-code docs,  the current code is based on the 'hashdriver2' script, and as such, does not utilize the 'amp' routines for S/P amplitude measurements. This will most likely be added in the near future. If someone wants to take it upon themselves to add the compiler directives in the source and the methods to the HashPype class, throw me a pull request.
 
 ### Installation
 
-The latest version of this code uses `numpy.distutils`, which can nicely compile Fortran code. The source code and makefiles to remake the libhashpy module are installed to the hashpy folder, so with a little hacking, one could just remake them in place, if one wanted to change the source code.
+The latest version of this code uses `numpy.distutils`, which can nicely compile Fortran code. 
+The source code and makefiles to remake the libhashpy module are installed to the hashpy folder, so with a little hacking, one could just remake them in place, if one wanted to change the source code.
 
 For basic install:
 
 ```shell
 # First, install dependencies. Then cd to this top directory and:
-python setup.py install
+python setup.py develop
 
 # or use pip
 pip install git+https://github.com/markcwill/hashpy.git
@@ -65,7 +71,11 @@ In [3]:
 
 ### Input/Output
 
-Data can be input into HASH in various formats. This is currently handled in HASHpy by registering a format in the `hashpy.io` module by adding a module/functions to the dictionary in `hashpy.io.core`. (May change in future releases). I/O functions are then called by the HashPype methods `HashPype.input()` and `HashPype.output()`. If the 'output' method is called with no format it will return a simple string with the event ID with the best strike/dip/rake
+Data can be input into HASH in various formats. 
+This is currently handled in HASHpy by registering a format in the `hashpy.io` module by adding a module/functions to the dictionary in `hashpy.io.core`. 
+(May change in future releases). 
+I/O functions are then called by the HashPype methods `HashPype.input()` and `HashPype.output()`. 
+If the `output` method is called with no format it will return a simple string with the event ID with the best strike/dip/rake
 
 Currently Supports:
 * ObsPy Event object I/O
@@ -145,7 +155,9 @@ A trial implementation of plotting exists, using `matplotlib` and the `mplstereo
 ### Future
 Add remaining HASH routines (like those in fmamp_subs.f) to wrapped library and class methods.
 
-If I ever get ambitious, I would redo the structure of some of the Fortran subroutines (already started this with vel-subs2) and rewrite them in Fortran 90/95/2003. Probably couldn't ditch the common blocks without a full rewrite, but at least try and get rid of the GOTOs. Biggest improvement would be allocatable arrays, so you could avoid the includes and max-size arrays.
+If I ever get ambitious, I would redo the structure of some of the Fortran subroutines (already started this with vel-subs2) and rewrite them in Fortran 90/95/2003. 
+Probably couldn't ditch the common blocks without a full rewrite, but at least try and get rid of the GOTOs. 
+Biggest improvement would be allocatable arrays, so you could avoid the includes and max-size arrays.
 
 There will probably be small adjustments to the locations and structure of what functions are in what files, but the HashPype class and methods will be the main way to interact with HASH.
 

--- a/hashpy/hashpype.py
+++ b/hashpy/hashpype.py
@@ -17,7 +17,7 @@ Module to call and run HASH subroutines in Fortran
 
 import numpy as np
 import os
-from pwd import getpwuid
+from getpass import getuser
 from hashpy.io.core import Inputter, Outputter
 from hashpy.libhashpy import (mk_table_add, angtable, ran_norm, get_tts, get_gap,
     focalmc, mech_prob, get_misf, focalamp_mc, get_misf_amp)
@@ -262,7 +262,7 @@ class HashPype(object):
         self.esaz    = np.empty(npick0, float)
         self.arid    = np.empty(npick0, int) * 0
         
-        self.author = getpwuid(os.getuid()).pw_name
+        self.author = getuser()
         
         if kwargs:
             self.__dict__.update(kwargs)

--- a/hashpy/src/fmamp_subs.f
+++ b/hashpy/src/fmamp_subs.f
@@ -35,11 +35,16 @@ c input and output arrays
       dimension p_azi_mc(npick0,nmc0),p_the_mc(npick0,nmc0)
       real sp_amp(npsta)
       real p_a1(npick0),p_a2(npick0),p_a3(npick0)
-      real faultnorm(3),slip(3),faults(3,nmax0),slips(3,nmax0)
+      real faultnorm(3),slip(3),faults(3,nmax0)
       real strike(nmax0),dip(nmax0),rake(nmax0)
       integer p_pol(npsta)
+
+      real,intent(out) ::  slips(3,nmax0)
+
       save dangold,nrot,b1,b2,b3    
       save amptable,phitable,thetable
+
+       
 cf2py intent(in)  p_azi_mc
 cf2py intent(in)  p_the_mc
 cf2py intent(in)  sp_amp
@@ -57,7 +62,7 @@ cf2py intent(out)  strike
 cf2py intent(out)  dip
 cf2py intent(out)  rake
 cf2py intent(out)  faults
-cf2py intent(out)  slips
+
 
 c coordinate transformation arrays
       real b1(3,ncoor),bb1(3)
@@ -171,7 +176,7 @@ c  Convert data to Cartesian coordinates
 40    continue
 
 c  find misfit for each solution and minimum misfit
-         nmis0min=1e5
+         nmis0min=100000
          qmis0min=1.0e5
          do 420 irot=1,nrot  
            qmis(irot)=0.

--- a/hashpy/src/util_subs.f
+++ b/hashpy/src/util_subs.f
@@ -2,16 +2,14 @@ c
 c  cross product of two vectors, sets v3 = v1 x v2
 c
       subroutine CROSS(v1,v2,v3)
-      real v1(3),v2(3),v3(3)
-
-cf2py intent(in) v1
-cf2py intent(in) v2
-cf2py intent(out) v3
+      implicit none
+      real,intent(in) :: v1(3),v2(3)
+      real,intent(out) :: v3(3)
 
       v3(1)=v1(2)*v2(3)-v1(3)*v2(2)   
       v3(2)=v1(3)*v2(1)-v1(1)*v2(3)
       v3(3)=v1(1)*v2(2)-v1(2)*v2(1)
-      return
+
       end   
 
 c ------------------------------------------------------------ c
@@ -24,8 +22,8 @@ c
       z=-r*cos(the*degrad)
       x=r*sin(the*degrad)*cos(phi*degrad)
       y=r*sin(the*degrad)*sin(phi*degrad)
-      return
-      end
+
+      end subroutine TO_CAR
 
 
 c ------------------------------------------------------------ c
@@ -78,8 +76,7 @@ c          print *,'***FPCOOR warning, horz fault, strike undefined'
          if (rake.le.-180.) rake=rake+360.
          if (rake.gt.180.) rake=rake-360.
       end if
-      return
-      end
+      end subroutine FPCOOR
 
 
 c ------------------------------------------------------------ c
@@ -87,7 +84,9 @@ c ------------------------------------------------------------ c
 c normally-distributed random numbers, from numerical recipes      
       subroutine RAN_NORM(fran)
       save jran,ifirst
-cf2py intent(out) fran
+
+      real,intent(out) :: fran
+
       im=120050                          !overflow at 2**28
       ia=2311
       ic=25367
@@ -95,12 +94,13 @@ cf2py intent(out) fran
          jran=314159
          ifirst=12345
       end if
-      fran=0
+
+      fran=0.
       do 10 i=1,12
         jran=mod(jran*ia+ic,im)
         fran=fran+(float(jran)/float(im))
 10    continue
       fran=fran-6.
-      return
-      end
+
+      end subroutine RAN_NORM
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 #
 import sys
 import os
+import setuptools #enables setup.py develop
 from numpy.distutils.core import setup, Extension
 
 


### PR DESCRIPTION
Fixes #7 

Gives examples of using Intents properly--I am noticing some issues with f2py where intents are missing.
You can use the comment `cf2py` method, but why not just declare the Intent to plain fortran as well, so that you can test them robustly against each other.