### PR TITLE
Two minor bug fixes to get hashpy to run in 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@ HASHpy
 ------
 
 This fork contains two minor bug fixes that are necessary to get hashpy up and running smoothly in 2021:
-. in hashpy/hashpype.py, change 'class HashError(StandardError):' to 'class HashError(Exception):'
-. in hashpy/__init__.py, add a dot before 'hashpype' and 'doublecouple'
+* in hashpy/hashpype.py, change 'class HashError(StandardError):' to 'class HashError(Exception):'
+* in hashpy/__init__.py, add a dot before 'hashpype' and 'doublecouple'
 
-That's it. Thank you Luca Scarabello for figuring this out. Now let's go compute some FMs :)
-
-
-
+That's it. Thank you Luca Scarabello for figuring this out. Now let's go compute some FMs (\\__/)
+- - - -
 
 
 
 
 
+
+#### Original README: ####
 
 [![DOI](https://zenodo.org/badge/3723/markcwill/hashpy.png)](http://dx.doi.org/10.5281/zenodo.9808)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 HASHpy
 ------
 
+This fork contains two minor bug fixes that are necessary to get hashpy up and running smoothly in 2021:
+. in hashpy/hashpype.py, change 'class HashError(StandardError):' to 'class HashError(Exception):'
+. in hashpy/__init__.py, add a dot before 'hashpype' and 'doublecouple'
+
+That's it. Thank you Luca Scarabello for figuring this out. Now let's go compute some FMs :)
+
+
+
+
+
+
+
+
+
 [![DOI](https://zenodo.org/badge/3723/markcwill/hashpy.png)](http://dx.doi.org/10.5281/zenodo.9808)
 
 This is a fork of HASH v1.2, the first motion focal mechanism program by Hardebeck and Shearer. The subroutines (in Fortran 77, which I did not write) are compiled into a python module, 'libhashpy.so', which will import all the subs and common blocks into the python namespace. There is a base class, HashPype, that contains attributes which hold data for a HASH calculation, and methods which can be called to do the HASH calculation. This class facilitates easily writing a 'hash driver' script in python. See below for details.

--- a/hashpy/__init__.py
+++ b/hashpy/__init__.py
@@ -10,8 +10,8 @@ using Python and HASH
 
 """
 
-from hashpype import HashPype, HashError
-from doublecouple import DoubleCouple
+from .hashpype import HashPype, HashError
+from .doublecouple import DoubleCouple
 
 __version__ = "0.5.6"
 

--- a/hashpy/hashpype.py
+++ b/hashpy/hashpype.py
@@ -514,7 +514,8 @@ class HashPype(object):
         self.calculate_quality(use_amplitudes=True)
 
 
-class HashError(StandardError):
+#class HashError(StandardError):
+class HashError(Exception):
     """Throw this if something happens while running"""
     pass
 


### PR DESCRIPTION
This fork contains two minor bug fixes that are necessary to get hashpy up and running smoothly in 2021:
* in hashpy/hashpype.py, change 'class HashError(StandardError):' to 'class HashError(Exception):'
* in hashpy/__init__.py, add a dot before 'hashpype' and 'doublecouple'